### PR TITLE
Legacy naming schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,44 @@ For an example event input file called 'event_input.txt', call structure is:
 ```bash
 $ pysep -c pysep_config.yaml -E event_input.txt
 ```
+
+--------------------------------------------------------------------------------
+### Legacy Filenaming Schema
+
+The new version of PySEP uses a file naming schema that is incompatible with 
+previous versions, which may lead to problems in established workflows. 
+
+To honor the legacy naming schema of PySEP, simply use the ``--legacy_naming`` 
+argument in the command line. This will change how the event tag is formatted,
+how the output directory is structured, and how the output SAC files are named.
+
+```bash
+$ pysep -c pysep_config.yaml --legacy_naming
+```
+
+--------------------------------------------------------------------------------
+### Output Filename Control
+
+The event tag used to name the output directory and written SAC files can be set
+manually by the user using the ``--event_tag`` argument. If not given, the tag 
+will default to a string consisting of event origin time and Flinn-Engdahl 
+region (or just origin time if ``--legacy_naming`` is used). Other output files 
+such as the config file and ObsPy objects can be set as in the following: 
+
+```bash
+$ pysep -c pysep_config.yaml \
+    --event_tag event_abc \
+    --config_fid event_abc.yaml \
+    --stations_fid event_abc_stations.txt \
+    --inv_fid event_abc_inv.xml \
+    --event_fid event_abc_event.xml \
+    --stream_fid event_abc_st.ms
+```
+
+Please note: the output SAC file names are hardcoded and cannot be changed 
+by the user. If this is a required feature, please open up a GitHub issue, and 
+the developers will address this need.
+
 --------------------------------------------------------------------------------
 
 ### Record Section plotter

--- a/pysep/utils/fmt.py
+++ b/pysep/utils/fmt.py
@@ -78,3 +78,17 @@ def format_event_tag(event):
     event_time = event.preferred_origin().time.strftime("%Y-%m-%dT%H%M%S")
 
     return f"{event_time}_{region}"
+
+
+def format_event_tag_legacy(event):
+    """
+    Generate a unique event tag based on the event time. This was how the
+    previous version of PySEP named directories and files. Replaces the old
+    `otime2eid` from `util_helpers`
+
+    :type event: obspy.core.event.Event
+    :param event: event to generate tag from
+    :rtype: str
+    :return: event_name specified by event time
+    """
+    return event.preferred_origin().time.strftime("%Y%m%d%H%M%S%f")[:-3]


### PR DESCRIPTION
This PR introduces the ability to use the legacy filename schema from the old version of PySEP, since the new naming schema may cause errors with workflows established using the old version of PySEP. 

Under the new schema, event tags are named after the origin time (as opposed to origin time + Flinn Engdahl region), and output SAC files are saved directly to the output directory (as opposed to the SAC/ directory). SAC file naming schema also changed to honor the legacy version, consisting of the new event tag concatenated with trace ids ending with a lower case component letter (e.g., BH.r, as opposed to BHR.sac).

It also allows the user to manually set the event tag (which controls output directory name and SAC file names), and the names of all the output files except for the SAC files (these are hard coded to include event tag and trace IDs). 

File names were checked against one event (Anchorage: 20090407201255351 or 2009-04-07T201255_SOUTHERN_ALASKA) and output directory and SAC files matched between legacy PySEP and new PySEP's legacy option.

Updated README to introduce these features in the command line tool section. 