### PR TITLE
Bug fix legacy naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ such as the config file and ObsPy objects can be set as in the following:
 
 ```bash
 pysep -c pysep_config.yaml \
-    --event_tag event_abc \
+    --overwrite_event_tag event_abc \
     --config_fid event_abc.yaml \
     --stations_fid event_abc_stations.txt \
     --inv_fid event_abc_inv.xml \

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -298,6 +298,10 @@ class RecordSection:
         if pysep_path is not None and os.path.exists(pysep_path):
             # Expecting to find SAC files labelled as such
             fids = glob(os.path.join(pysep_path, "*.sac"))
+            if not fids:
+                # Or if legacy naming schema, assume that the sac files have a
+                # given file format: event_tag.NN.SSS..LL.CC.c
+                fids = glob(os.path.join(pysep_path, "*.*.*.*.*.?"))
             if fids:
                 logger.info(f"Reading {len(fids)} files from: {pysep_path}")
                 # Overwrite stream, so reading takes precedence


### PR DESCRIPTION
Bug fix for PySEP ignoring automatic file naming for config files that it has already generated. 

1) Changed 'event_tag' overwrite parameter to 'overwrite_event_tag' so as to not confuse the actual attribute
2) Made 'legacy_naming' attribute hidden so that it doesnt get written to the config file and overwrite the users decision to use legacy naming.
3) recsec can now recognize legacy filenames for SAC files, whereas before it would have failed to locate them because they are not suffixed with '.sac'
4) updated readme to reflect change in 'overwrite_event_tag' parameter