### PR TITLE
Bugfix sac errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ such as the config file and ObsPy objects can be set as in the following:
 
 ```bash
 pysep -c pysep_config.yaml \
-    --event_tag event_abc \
+    --overwrite_event_tag event_abc \
     --config_fid event_abc.yaml \
     --stations_fid event_abc_stations.txt \
     --inv_fid event_abc_inv.xml \

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1086,7 +1086,9 @@ class Pysep:
             self.st = st
         self.st = quality_check_waveforms_before_processing(self.st)
         self.st = append_sac_headers(self.st, self.event, self.inv)
-        self.st = format_sac_header_w_taup_traveltimes(self.st, self.taup_model)
+        if self.taup_model is not None:
+            self.st = format_sac_header_w_taup_traveltimes(self.st, 
+                                                           self.taup_model)
 
         # Waveform preprocessing and standardization
         self.st = self.preprocess()

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -298,6 +298,10 @@ class RecordSection:
         if pysep_path is not None and os.path.exists(pysep_path):
             # Expecting to find SAC files labelled as such
             fids = glob(os.path.join(pysep_path, "*.sac"))
+            if not fids:
+                # Or if legacy naming schema, assume that the sac files have a
+                # given file format: event_tag.NN.SSS..LL.CC.c
+                fids = glob(os.path.join(pysep_path, "*.*.*.*.*.?"))
             if fids:
                 logger.info(f"Reading {len(fids)} files from: {pysep_path}")
                 # Overwrite stream, so reading takes precedence

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -53,7 +53,7 @@ def test_append_sac_headers(test_st, test_inv, test_event):
     assert(st[0].stats.sac["evla"] == test_event.preferred_origin().latitude)
 
 
-def test_event_tag_legacy(test_event):
+def test_event_tag_and_event_tag_legacy(test_event):
     """
     Check that event tagging works as expected
     """

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -14,7 +14,7 @@ from pysep.utils.cap_sac import (append_sac_headers,
 from pysep.utils.curtail import (remove_for_clipped_amplitudes, rename_channels,
                                  remove_stations_for_missing_channels,
                                  remove_stations_for_insufficient_length)
-from pysep.utils.fmt import format_event_tag
+from pysep.utils.fmt import format_event_tag, format_event_tag_legacy
 from pysep.utils.plot import plot_source_receiver_map
 from pysep.utils.io import read_synthetics
 
@@ -52,9 +52,17 @@ def test_append_sac_headers(test_st, test_inv, test_event):
     assert(hasattr(st[0].stats, "sac"))
     assert(st[0].stats.sac["evla"] == test_event.preferred_origin().latitude)
 
+
+def test_event_tag_legacy(test_event):
+    """
+    Check that event tagging works as expected
+    """
     # while were here, make sure event tagging works
     tag = format_event_tag(test_event)
     assert(tag == "2009-04-07T201255_SOUTHERN_ALASKA")
+
+    tag = format_event_tag_legacy(test_event)
+    assert(tag == "20090407201255351")
 
 
 def test_format_sac_headers_w_taup_traveltimes(test_st, test_inv, test_event):

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -10,7 +10,7 @@ from obspy.core.stream import Stream
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from pysep import logger
-from pysep.utils.fmt import format_event_tag
+from pysep.utils.fmt import format_event_tag_legacy
 from pysep.utils.fetch import get_taup_arrivals_with_sac_headers
 
 # SAC HEADER CONSTANTS DEFINING NON-INTUITIVE QUANTITIES
@@ -174,6 +174,7 @@ def _append_sac_headers_trace(tr, event, inv):
     dist_deg = kilometer2degrees(dist_km)  # spherical earth approximation
 
     sac_header = {
+        "o": tr.stats.starttime - event.preferred_origin().time,
         "evla": event.preferred_origin().latitude,
         "evlo": event.preferred_origin().longitude,
         "evdp": event.preferred_origin().depth / 1E3,  # depth in km
@@ -181,7 +182,7 @@ def _append_sac_headers_trace(tr, event, inv):
         "stla": sta.latitude,
         "stlo": sta.longitude,
         "stel": sta.elevation / 1E3,  # elevation in km
-        "kevnm": format_event_tag(event),
+        "kevnm": format_event_tag_legacy(event),  # only take date code
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -149,6 +149,11 @@ def _append_sac_headers_trace(tr, event, inv):
     TODO Add back in information removed from original function
         * Add sensor type somewhere, previously stored in KT? (used for picks)
 
+    .. note::
+        We explicitely set 'iztype, 'b' and 'e' in the SAC header to tell ObsPy
+        that the trace start is NOT the origin time. Otherwise all the relative
+        timing (e.g., picks) will be wrong.
+
     :type tr: obspy.core.trace.Trace
     :param tr: Trace to append SAC header to
     :type event: obspy.core.event.Event
@@ -174,7 +179,9 @@ def _append_sac_headers_trace(tr, event, inv):
     dist_deg = kilometer2degrees(dist_km)  # spherical earth approximation
 
     sac_header = {
-        "o": tr.stats.starttime - event.preferred_origin().time,
+        "iztype": 9,  # Ref time equivalence, IB (9): Begin time
+        "b": tr.stats.starttime - event.preferred_origin().time,  # begin time
+        "e": tr.stats.npts * tr.stats.delta,  # end time
         "evla": event.preferred_origin().latitude,
         "evlo": event.preferred_origin().longitude,
         "evdp": event.preferred_origin().depth / 1E3,  # depth in km

--- a/pysep/utils/fmt.py
+++ b/pysep/utils/fmt.py
@@ -72,9 +72,10 @@ def format_event_tag(event):
 
     client = Client()
     region = client.flinnengdahl(lat=event_lat, lon=event_lon, rtype="region")
+    # e.g. NORTH ISLAND, NEW ZEALAND > NORTH_ISLAND_NEW_ZEALAND
     region = region.replace(" ", "_").replace(",", "").upper()
 
-    # Presumed to be event name specified by origintime
+    # Presumed to be event name specified by origintime, e..g, 20090407T201255
     event_time = event.preferred_origin().time.strftime("%Y-%m-%dT%H%M%S")
 
     return f"{event_time}_{region}"


### PR DESCRIPTION
This PR fixes some issues with writing the output SAC waveform files

- Bug fixes SAC thinking the trace start time was the event origin time (spoiler alert: it's not) by setting IZTYPE, E and B as SAC header attributes, which tell ObsPy to consider trace start as a reference time, not origin time
- KEVNM (event name) was being truncated weirdly because SAC only allows 16 characters for thsi field. KEVNM is now always set as the legacy-style event tag, which is a 16 character tag generated from the event origin time (up to milliseconds)
- Allow user to ignore appending TauP picks to the SAC header by setting `taup_model`==None

- Added tests to cover origin times and the legacy file naming introduced in #22 

Misc changes:
- Event tags can now be overwritten by user, otherwise they have default and legacy event tags available
- RecSec can now find files in a legacy event directory 