### PR TITLE
add feature pre-filtering

### DIFF
--- a/pysep/configs/alvizuri_tape_2018/2006-10-09T013528_NORTH_KOREA.yaml
+++ b/pysep/configs/alvizuri_tape_2018/2006-10-09T013528_NORTH_KOREA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 20
 remove_clipped: false

--- a/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NODAL.yaml
+++ b/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NODAL.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NONNODAL.yaml
+++ b/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NONNODAL.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/misc_events/1988-02-15T181000_KERNVILLE_EXPLOSION.yaml
+++ b/pysep/configs/misc_events/1988-02-15T181000_KERNVILLE_EXPLOSION.yaml
@@ -35,7 +35,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: 
+pre_filt: default
 scale_factor: 100
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/misc_events/2016-01-24T103037_INISKIN.yaml
+++ b/pysep/configs/misc_events/2016-01-24T103037_INISKIN.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 1
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2009-04-07T201255_ANCHORAGE.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2009-04-07T201255_ANCHORAGE.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2014-08-25T161903_ICELAND.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2014-08-25T161903_ICELAND.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2017-09-03T033001_NORTH_KOREA.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2017-09-03T033001_NORTH_KOREA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 5
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2020-04-04T015318_SOUTHERN_CALIFORNIA.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2020-04-04T015318_SOUTHERN_CALIFORNIA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/scec/2002-03-16T213324_SOUTHERN_CALIFORNIA.yaml
+++ b/pysep/configs/scec/2002-03-16T213324_SOUTHERN_CALIFORNIA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/tape_etal_2018/2012-04-11T092157_TAPE_2018.yaml
+++ b/pysep/configs/tape_etal_2018/2012-04-11T092157_TAPE_2018.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/template_config.yaml
+++ b/pysep/configs/template_config.yaml
@@ -35,7 +35,7 @@ rotate: null
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -15,6 +15,7 @@ from pysep.utils.curtail import (remove_for_clipped_amplitudes, rename_channels,
                                  remove_stations_for_missing_channels,
                                  remove_stations_for_insufficient_length)
 from pysep.utils.fmt import format_event_tag, format_event_tag_legacy
+from pysep.utils.process import estimate_prefilter_corners
 from pysep.utils.plot import plot_source_receiver_map
 from pysep.utils.io import read_synthetics
 
@@ -149,6 +150,18 @@ def test_read_synthetics():
                               stations=test_stations)
 
     assert(st[0].stats.sac.evla == -40.5405)
+
+
+def test_estimate_prefilter_corners(test_st):
+    """
+    Test prefilter corner estimation based on trace starts time and samp rate
+    """
+    for tr in test_st:
+        f0, f1, f2, f3 = estimate_prefilter_corners(tr)
+        assert(f0 == pytest.approx(.0214, 3))
+        assert(f1 == pytest.approx(.0427, 3))
+        assert(f2 == pytest.approx(12.5, 3))
+        assert(f3 == pytest.approx(25.0, 3))
 
 
 @pytest.mark.skip(reason="need to find correct clipped example data")

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -316,3 +316,31 @@ def zerophase_chebychev_lowpass_filter(tr, freqmax):
                          output="ba")                                   # NOQA
     # Apply twice to get rid of the phase distortion.
     tr.data = signal.filtfilt(b, a, tr.data)
+
+
+def estimate_prefilter_corners(tr):
+    """
+    Estimates corners for pre-deconvolution (instrument response removal)
+    Essentially band limits the data based on the minimum and maximum allowable
+    periods based on the sampling rate and overall waveform length.
+
+    See also: https://ds.iris.edu/files/sac-manual/commands/transfer.html
+
+    Replaces the old `get_pre_filt` function
+
+    :type tr: obspy.core.trace.Trace
+    :param tr: trace from which stats are taken
+    :rtype: tuple of float
+    :return: frequency corners (f0, f1, f2, f3)
+    """
+    # filtering constants
+    fcut1_par = 4.0
+    fcut2_par = 0.5
+
+    f1 = fcut1_par / (tr.stats.endtime - tr.stats.starttime)
+    nyquist_freq = tr.stats.sampling_rate / 2
+    f2 = nyquist_freq * fcut2_par
+    f0 = 0.5 * f1
+    f3 = 2.0 * f2
+
+    return f0, f1, f2, f3


### PR DESCRIPTION
re-introduces default pre-filtering option that was present in old PySEP, which calculates pre-filter corners and applies pre-filtering during instrument response removal based on waveform length and trace sampling rate.

This is made the default behavior of the pre-filter option, all default config files are now updated with this 'default' behavior if their prefilt option was set as None. Adds in a test to check the pre-filter estimation function.