### PR TITLE
Feature zeropad

### DIFF
--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1233,8 +1233,9 @@ class RecordSection:
         
         # These are still the entire waveform. Make sure we honor zero padding
         # and any time shift applied
-        zero_pad_start, zero_pad_end = self.zero_pad_s
-        x = tr.times() + tshift - zero_pad_start
+        x = tr.times() + tshift
+        if self.zero_pad_s is not None:
+            x -= self.zero_pad_s[0]  # index 0 is start, index 1 is end
         y = tr.data / self.amplitude_scaling[idx] + self.y_axis[y_index]
 
         # Truncate waveforms to get figure scaling correct. 

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -317,8 +317,12 @@ class RecordSection:
 
         # Read in SPECFEM generated synthetics and generate SAC headed streams
         if syn_path is not None and os.path.exists(syn_path):
-            assert(cmtsolution is not None and os.path.exists(cmtsolution))
-            assert(stations is not None and os.path.exists(stations))
+            assert(cmtsolution is not None and os.path.exists(cmtsolution)), (
+                f"If `syn_path` is given, RecSec also requires `cmtsolution`"
+            )
+            assert(stations is not None and os.path.exists(stations)), (
+                f"If `syn_path` is given, RecSec also requires `stations`"
+            )
             fids = glob(os.path.join(syn_path, "??.*.*.sem?*"))
             if fids:
                 logger.info(f"Reading {len(fids)} synthetics from: {syn_path}")
@@ -527,10 +531,11 @@ class RecordSection:
             err.save = (f"path {self.save} already exists. Use '--overwrite' " 
                         f"flag to save over existing figures.")
 
-        _dirname = os.path.abspath(os.path.dirname(self.save))
-        if not os.path.exists(_dirname):
-            logger.info(f"creating output directory {_dirname}")
-            os.makedirs(_dirname)
+        if self.save:
+            _dirname = os.path.abspath(os.path.dirname(self.save))
+            if not os.path.exists(_dirname):
+                logger.info(f"creating output directory {_dirname}")
+                os.makedirs(_dirname)
 
         if err:
             out = "ERROR - Parameter errors, please make following changes:\n"
@@ -608,7 +613,8 @@ class RecordSection:
         # zoomed in on the P-wave, max amplitude should NOT be the surface wave)
         for tr, xlim in zip(self.st, self.xlim):
             start, stop = xlim
-            self.max_amplitudes.append(max(abs(tr.data[start:stop])))
+            self.max_amplitudes = np.append(self.max_amplitudes,
+                                            max(abs(tr.data[start:stop])))
         self.max_amplitudes = np.array(self.max_amplitudes)
 
         # Figure out which indices we'll be plotting
@@ -1366,7 +1372,7 @@ class RecordSection:
             else:
                 loc = self.y_label_loc
             self._set_y_axis_text_labels(start=start, stop=stop, loc=loc)
-        logger.info(f"placing station labels on y-axis at: {loc}")
+            logger.info(f"placing station labels on y-axis at: {loc}")
 
         # User requests that we turn off y-axis
         if self.y_label_loc is None:

--- a/pysep/tests/test_recsec.py
+++ b/pysep/tests/test_recsec.py
@@ -1,0 +1,123 @@
+"""
+Test the general functionality of the RECord SECtion plotter.
+
+.. note::
+    This test suite simply creates some plots to make sure the general
+    machinery is working as expected, but otherwise has no real solid checks on
+    the outputs. If this code grows more cumbersome, we will want to do figure
+    matching checks or something more sophisticated.
+"""
+import os
+import pytest
+from copy import copy
+from pysep import RecordSection
+
+
+@pytest.fixture
+def recsec(tmpdir):
+    """Initiate a RecordSection instance"""
+    return RecordSection(pysep_path="./test_data/test_SAC", show=False,
+                         save=os.path.join(tmpdir, "recsec.png"))
+
+
+@pytest.fixture
+def recsec_w_synthetics(tmpdir):
+    """Initiate a RecordSection instance"""
+    return RecordSection(pysep_path="./test_data/test_SAC",
+                         syn_path="./test_data/test_synthetics",
+                         cmtsolution="./test_data/test_CMTSOLUTION_2014p715167",
+                         stations="./test_data/test_STATIONS",
+                         show=False, save=os.path.join(tmpdir, "recsec.png"))
+
+
+def test_plot_recsec(recsec):
+    """Simply test out the functinoality of plotw_rs"""
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()
+
+
+def test_plot_recsec_w_synthetics(recsec_w_synthetics):
+    """Simply test out the functinoality of plotw_rs"""
+    recsec_w_synthetics.process_st()
+    recsec_w_synthetics.get_parameters()
+    recsec_w_synthetics.plot()
+
+
+def test_plot_recsec_sort_by(recsec):
+    """Simply test out the functinoality of plotw_rs"""
+    acceptable_sort_by = ["default", "azimuth", "backazimuth",
+                          "distance", "alphabetical", "abs_azimuth",
+                          "abs_distance"]
+    for sort_by in acceptable_sort_by:
+        recsec_test = copy(recsec)
+        recsec_test.sort_by = sort_by
+        recsec_test.process_st()
+        recsec_test.get_parameters()
+        recsec_test.save = f"{recsec.save}_{sort_by}.png"
+        recsec_test.plot()
+
+
+def test_plot_recsec_scale_by(recsec):
+    """scale by option testing"""
+    acceptable_scale_by = ["normalize", "global_norm"]
+                           # "geometric_spreading"]
+    for scale_by in acceptable_scale_by:
+        recsec_test = copy(recsec)
+        recsec_test.scale_by = scale_by
+        recsec_test.process_st()
+        recsec_test.get_parameters()
+        recsec_test.save = f"{recsec.save}_{scale_by}.png"
+        recsec_test.plot()
+
+
+def test_plot_recsec_time_shift(recsec):
+    """apply a whole bunch of time shift elements"""
+    recsec.time_shift_s = 100
+    recsec.zero_pad_s = [200, 500]
+    recsec.move_out = 4
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()
+
+
+def test_plot_recsec_preprocess(recsec):
+    """preprocess and filter the record section"""
+    recsec.min_period_s = 10
+    recsec.max_period_s = 30
+    recsec.integrate = 2
+    recsec.components = "ZN"
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()
+
+
+def test_plot_recsec_y_label_loc(recsec):
+    """test all available y_label locations options"""
+    acceptable_y_label_loc = ["default", "y_axis", "y_axis_right", "x_min",
+                              "x_max", None]
+    recsec.process_st()
+    recsec.get_parameters()
+    for y_label_loc in acceptable_y_label_loc:
+        recsec.y_label_loc = y_label_loc
+        recsec.plot()
+
+
+def test_plot_recsec_distance_units(recsec):
+    """test all available distance units"""
+    acceptable_distance_units = ["km", "km_utm", "deg"]
+    for distance_units in acceptable_distance_units:
+        recsec.distance_units = distance_units
+        recsec.process_st()
+        recsec.get_parameters()
+        recsec.plot()
+
+
+def test_plot_recsec_plot_options(recsec):
+    """test plotting options"""
+    recsec.y_axis_spacing = 3.5
+    recsec.amplitude_scale_factor = 8.2
+    recsec.azimuth_start_deg = 102.1
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()


### PR DESCRIPTION
Adds in zero padding for the RECord SECtion tool, which allows the User to pad zeros at the start and end of a trace. This occurs after detrending/tapering, but before filtering, which is meant to accommodate a continuous waveform (as opposed to having a jump from zero to some nonzero amplitude).

Also adds in a pytest test suite for the record section plotter. These tests are simple, they just test all the options by running RecSec with a variety of input parameters to make sure code executes but there are no checks for image creation. Probably okay for the current scale of RecSec, but if it becomes a larger tool we may need to rethink how to structure its tests