### PR TITLE
Bugfix rotation

### DIFF
--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -859,8 +859,15 @@ class Pysep:
             st_out += st_uvw
         elif "RTZ" in self.rotate:
             logger.info("rotating to components RTZ")
+            # For some reason, when we rotate the ENTIRE stream at once, T and R
+            # components get flipped and shifted (i.e., WRONG). But if we go
+            # station by station, rotation results comes out differently (i.e.,
+            # they match Legacy PySEP results)
             st_rtz = st_raw.copy()
-            st_rtz.rotate("NE->RT", inventory=self.inv)
+            stations = set([tr.stats.station for tr in st_rtz])
+            for sta in stations:
+                _st = st_rtz.select(station=sta)
+                _st.rotate("NE->RT")  # in place rot.
             st_out += st_rtz
 
         st_out = format_sac_headers_post_rotation(st_out)

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -34,7 +34,8 @@ from pysep.utils.io import read_yaml, read_event_file, write_stations_file
 from pysep.utils.llnl import scale_llnl_waveform_amplitudes
 from pysep.utils.process import (merge_and_trim_start_end_times, resample_data,
                                  format_streams_for_rotation, rotate_to_uvw,
-                                 estimate_prefilter_corners)
+                                 estimate_prefilter_corners,
+                                 append_back_azimuth_to_stats)
 from pysep.utils.plot import plot_source_receiver_map
 from pysep.recsec import plotw_rs
 
@@ -834,8 +835,9 @@ class Pysep:
             with SAC headers that have been adjusted for the rotation
         """
         st_out = self.st.copy()
-
         st_out = format_streams_for_rotation(st_out)
+        st_out = append_back_azimuth_to_stats(st=st_out, inv=self.inv,
+                                              event=self.event)
         if "ZNE" in self.rotate:
             logger.info("rotating to components ZNE")
             st_out.rotate(method="->ZNE", inventory=self.inv)
@@ -1111,7 +1113,8 @@ class Pysep:
 
         # Waveform preprocessing and standardization
         self.st = self.preprocess()
-        self.st = self.rotate_streams()
+        if self.rotate is not None:
+            self.st = self.rotate_streams()
         self.st = quality_check_waveforms_after_processing(self.st)
 
         # Generate outputs for user consumption

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -653,7 +653,19 @@ class RecordSection:
             for tr, tshift in zip(self.st, self.time_shift_s):
                 start, stop = [int(_/tr.stats.delta) for _ in self.xlim_s]
                 sshift = int(tshift / tr.stats.delta)  # unit: samples
-                xlim.append((start-sshift, stop-sshift))
+                # These indices define the index of the user-chosen timestamp
+                start_index = start - sshift
+                end_index = stop - sshift
+                # Shift by the total amount that the zero pad adjusted starttime
+                if self.zero_pad_s:
+                    zero_pad_index = int(self.zero_pad_s[0]/tr.stats.delta)
+                    start_index += zero_pad_index
+                    end_index += zero_pad_index
+                assert(start_index >= 0), (
+                    f"trying to access negative time but trace has no negative "
+                    f"time values. Please check your choice for `xlim_s`"
+                )
+                xlim.append((start_index, end_index))
 
         xlim = np.array(xlim)
         return xlim

--- a/pysep/tests/test_process.py
+++ b/pysep/tests/test_process.py
@@ -9,11 +9,11 @@ import pytest
 import numpy as np
 from obspy import read, read_events, read_inventory
 
-from pysep import logger
+from pysep import logger, Pysep
 from pysep.utils.cap_sac import append_sac_headers
 from pysep.utils.process import (merge_and_trim_start_end_times,
                                  resample_data, format_streams_for_rotation,
-                                 rotate_to_uvw)
+                                 rotate_to_uvw, append_back_azimuth_to_stats)
 
 logger.setLevel("DEBUG")  # DELETEME
 
@@ -109,3 +109,48 @@ def test_rotate_to_uvw(test_st):
     for tr in st_out:
         assert(tr.stats.component in ["U", "V", "W"])
 
+
+def test_append_back_azimuth_to_stats(test_st, test_inv, test_event):
+    """
+    Check that back azimuth values are appended correctly
+    """
+    # ensure that test data doesn't have any back azimuth stats
+    for tr in test_st:
+        del tr.stats.back_azimuth
+    assert("back_azimuth" not in test_st[0].stats)
+
+    st = append_back_azimuth_to_stats(st=test_st, inv=test_inv,
+                                      event=test_event)
+    check_dict = {"ATKA": 45.514, "BESE": 297.444, "ALPI": 335.115}
+    for tr in st:
+        assert(check_dict[tr.stats.station] ==
+               pytest.approx(tr.stats.back_azimuth, 3))
+
+
+def test_rotate_streams(test_st, test_inv, test_event):
+    """
+    Ensure that stream rotation works as expected
+    """
+    sep = Pysep(log_level="CRITICAL")
+    for tr in test_st:
+        del tr.stats.back_azimuth
+    assert("back_azimuth" not in test_st[0].stats)
+
+    sep.st = test_st
+    sep.inv = test_inv
+    sep.event = test_event
+    sep.st = sep.preprocess()  # make sure that streams are formatted correctly
+    st_rotated = sep.rotate_streams()
+    # Make sure components have been rotated
+    for tr in sep.st:
+        assert(tr.stats.component not in ["R", "T"])
+    for tr in st_rotated:
+        assert(tr.stats.component not in ["N", "E"])
+
+    # check that data has been changed for horizontal components
+    for tr, tr_rot in zip(sep.st, st_rotated):
+        assert(tr.stats.station == tr_rot.stats.station)
+        if tr.stats.component == "Z":
+            assert(np.any(tr.data == tr_rot.data))
+        else:
+            assert(np.any(tr.data != tr_rot.data))

--- a/pysep/tests/test_pysep.py
+++ b/pysep/tests/test_pysep.py
@@ -74,3 +74,4 @@ def test_curtail_stations(test_pysep):
     nsta_post_curtail = len(inv.get_contents()["channels"])
 
     assert(nsta_pre_curtail - nsta_post_curtail == 6)
+

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -142,7 +142,8 @@ def append_sac_headers(st, event, inv):
 
 def _append_sac_headers_trace(tr, event, inv):
     """
-    Append SAC headers to ObsPy streams given event and station metadata
+    Append SAC headers to ObsPy streams given event and station metadata.
+    Also add 'back_azimuth' to Stream stats which can be used for rotation.
 
     Rewritten from: `util_write_cap.add_sac_metadata()`
 
@@ -205,6 +206,7 @@ def _append_sac_headers_trace(tr, event, inv):
     except IndexError:
         pass
 
+    # Append SAC header and include back azimuth for rotation
     tr.stats.sac = sac_header
     tr.stats.back_azimuth = baz
 

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -66,6 +66,10 @@ def append_back_azimuth_to_stats(st, inv, event):
     trace.stats.back_azimuth. This function appends back azimuth values to the
     stream by cacluating using metadata from the inventory and event objects.
 
+    .. note::
+        This was written and then I realized that `_append_sac_headers_trace`
+        already does this, so it is unused, but left incase it's useful later.
+
     :type st: obspy.core.stream.Stream
     :param st: Stream with missing components
     :type inv: obspy.core.inventory.Inventory

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy import signal
 
 from obspy import Stream
+from obspy.geodetics import gps2dist_azimuth
 from pysep import logger
 from pysep.utils.fmt import get_codes
 
@@ -56,6 +57,37 @@ def format_streams_for_rotation(st):
 
     logger.info(f"stream formatting returned {len(st_out)} traces")
 
+    return st_out
+
+
+def append_back_azimuth_to_stats(st, inv, event):
+    """
+    ObsPy rotation requires back azimuth information which is accessed through
+    trace.stats.back_azimuth. This function appends back azimuth values to the
+    stream by cacluating using metadata from the inventory and event objects.
+
+    :type st: obspy.core.stream.Stream
+    :param st: Stream with missing components
+    :type inv: obspy.core.inventory.Inventory
+    :param inv: optional user-provided inventory object which will force a
+        skip over StationXML/inventory searching
+    :type event: obspy.core.event.Event
+    :param event: optional user-provided event object which will force a
+        skip over QuakeML/event searching
+    :rtype: obspy.core.stream.Stream
+    :return: stream with back azimuth values appended
+    """
+    st_out = st.copy()
+    ev_lat = event.preferred_origin().latitude
+    ev_lon = event.preferred_origin().longitude
+    for net in inv:
+        for sta in net:
+            _, _, baz = gps2dist_azimuth(lat1=ev_lat, lon1=ev_lon,
+                                         lat2=sta.latitude, lon2=sta.longitude
+                                         )
+            # Apply back azimuth changes to stream in place
+            for tr in st_out.select(network=net.code, station=sta.code):
+                tr.stats.back_azimuth = baz
     return st_out
 
 


### PR DESCRIPTION
This PR fixes a rotation bug pointed out by @ammcpherson, who noticed RTZ rotated streams in the current PySEP version did not match those from the legacy codebase. 

This is related to an ObsPy bug (https://github.com/obspy/obspy/issues/2623) which causes the Stream().rotate() function to use the FIRST backazimuth (BAz) value to rotate all traces in a stream even if they don't share this BAz value. This cased rotation to essentially fail silently.

As a bugfix, during NE->RT rotation, we rotate station by station, which provides the correct BAz value for each rotation. 

Also, fixes a RecSec bug where zero padding and setting x limits together was leading to an incorrectly defined time axis.