### PR TITLE
add workflow to trigger container build

### DIFF
--- a/.github/workflows/dispatch-container.yml
+++ b/.github/workflows/dispatch-container.yml
@@ -1,0 +1,22 @@
+name: Dispatch Container Build
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'SeisSCOPED',
+              repo: 'pysep',
+              event_type: 'build_container'
+            })


### PR DESCRIPTION
This is the workflow to trigger the container build workflow at https://github.com/SeisSCOPED/pysep/blob/main/.github/workflows/docker-publish.yml 
Note that an admin of this repo will need to add a PAT and name it as `PAT_TOKEN` in this repository's secret to make it work. We also need to grant this admin write access to the pysep container repo.