### PR TITLE
Merging devel in master

### DIFF
--- a/.github/workflows/dispatch-container.yml
+++ b/.github/workflows/dispatch-container.yml
@@ -1,0 +1,22 @@
+name: Dispatch Container Build
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'SeisSCOPED',
+              repo: 'pysep',
+              event_type: 'build_container'
+            })

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This will set two command line tools `pysep` and `recsec`
 ```bash
 $ conda create -n pysep python=3.10
 $ conda activate pysep
-$ git clone --branch devel https://github.com/uafgeotools/pysep.git
+$ git clone https://github.com/uafgeotools/pysep.git
 $ cd pysep
 $ conda install --file requirements.txt
 $ pip install -e .
@@ -50,7 +50,7 @@ $ pip install -e .
 PySEP comes with unit testing which should be run before and after making any
 changes to see if your changes have altered the expected code behavior.
 ```bash
-$ cd tests
+$ cd pytest/tests
 $ pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Chinook.
 ```bash
 module load singularity
 singularity pull docker://ghcr.io/seisscoped/container-base:centos7
-singularity exec -c container-base:centos7.sif pysep -h
+singularity exec -c container-base_centos7.sif pysep -h
 ```
 
 To run a data download we will need to mount the local filesystem into the

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ To run a data download we will need to mount the local filesystem into the
 container using the ``--bind`` command. Using the Anchorage example event:
 
 ```bash
-singularity exec -c --bind $(pwd):/home1 container-base:centos7.sf \
+singularity exec -c --bind $(pwd):/home1 container-base_centos7.sif \
     bash -c "cd /home1/; pysep -p mtuq_workshop_2022 -e 2009-04-07T201255_ANCHORAGE.yaml"
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ argument in the command line. This will change how the event tag is formatted,
 how the output directory is structured, and how the output SAC files are named.
 
 ```bash
-$ pysep -c pysep_config.yaml --legacy_naming
+pysep -c pysep_config.yaml --legacy_naming
 ```
 
 --------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ region (or just origin time if ``--legacy_naming`` is used). Other output files
 such as the config file and ObsPy objects can be set as in the following: 
 
 ```bash
-$ pysep -c pysep_config.yaml \
+pysep -c pysep_config.yaml \
     --event_tag event_abc \
     --config_fid event_abc.yaml \
     --stations_fid event_abc_stations.txt \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 Python Seismogram Extraction and Processing
 ===========================================
 
+`PySEP` is a waveform and metadata download tool. The package also contains
+`RecSec`, a record section plotting tool. 
+
+## Introduction
+
 `PySEP` uses ObsPy tools to request seismic data and metadata, process, 
-standardize and format the data, and write out SAC files with the underlying 
+standardize and format waveform data, and write out SAC files with the underlying 
 motivation of preparing data for moment tensor inversions, although the 
-written files can be used for other purposes.
+written files can be used for other purposes. 
 
 The main processing steps taken by `PySEP` are:
 
@@ -23,7 +28,7 @@ The main processing steps taken by `PySEP` are:
 11. Write config YAML files which can be used to re-run data gathering/processing
 12. Plot a record section and source-receiver map
 
-PySEP also has the capacity to:
+`PySEP` also has the capacity to:
 
 * Interface with a Lawrence Livermore National Laboratory database of nuclear
   explosion and earthquake waveforms (see note)
@@ -31,30 +36,30 @@ PySEP also has the capacity to:
 * Access pre-defined configuration files for data used in previous studies 
 * Input custom TauP models for arrival time estimation
 
-### Installation
+## Installation
 
 We recommend installing PySEP into a Conda environment. Dependencies are 
 installed via Conda where possible, with Pip used to install PySEP itself. 
 This will set two command line tools `pysep` and `recsec`
 ```bash
-$ conda create -n pysep python=3.10
-$ conda activate pysep
-$ git clone https://github.com/uafgeotools/pysep.git
-$ cd pysep
-$ conda install --file requirements.txt
-$ pip install -e .
+conda create -n pysep python=3.10
+conda activate pysep
+git clone https://github.com/uafgeotools/pysep.git
+cd pysep
+conda install --file requirements.txt
+pip install -e .
 ```
 
-### Running Tests
+## Running Tests
 
 PySEP comes with unit testing which should be run before and after making any
 changes to see if your changes have altered the expected code behavior.
 ```bash
-$ cd pysep/tests
-$ pytest
+cd pysep/tests
+pytest
 ```
 
-### Gallery
+## Gallery
 
 An example record section produced by the `recsec` tool inside PySEP
 
@@ -73,13 +78,14 @@ Normal users should use PySEP as a command line tool.
 To bring up the command line tool help message:
 
 ```bash
-$ pysep -h 
+pysep -h 
 ```
 
 To list out available pre-defined configuration files
 
 ```bash
-$ pysep -l  # or pysep --list
+pysep -l  # or pysep --list
+
 -p/--preset -e/--event
 -p MTUQ2022_workshop -e 2009-04-07T201255_ANCHORAGE.yaml
 -p MTUQ2022_workshop -e 2014-08-25T161903_ICELAND.yaml
@@ -90,20 +96,20 @@ $ pysep -l  # or pysep --list
 To run one of the pre-defined configuration files
 
 ``` bash
-$ pysep -p MTUQ2022_workshop -e 2017-09-03T033001_NORTH_KOREA.yaml 
+pysep -p MTUQ2022_workshop -e 2017-09-03T033001_NORTH_KOREA.yaml 
 ```
 
 To create a template configuration file that you must fill out with your own
 parameters
 
 ```bash
-$ pysep -W  # or pysep --write
+pysep -W  # or pysep --write
 ```
 
 To run this newly created configuration file
 
 ```bash
-$ pysep -c pysep_config.yaml
+pysep -c pysep_config.yaml
 ```
 
 --------------------------------------------------------------------------------
@@ -123,11 +129,11 @@ the following parameters as columns:
 For an example event input file called 'event_input.txt', call structure is:
 
 ```bash
-$ pysep -c pysep_config.yaml -E event_input.txt
+pysep -c pysep_config.yaml -E event_input.txt
 ```
 --------------------------------------------------------------------------------
 
-### Record Section plotter
+## Record Section plotter
 
 PySEP also comes with a pretty sophisticated record section tool, which plots
 seismic data acquired by PySEP. When you have successfully collected your data,
@@ -137,31 +143,31 @@ it will reside in the /SAC folder of the PySEP output directory.
 To see available record section plotting commands
 
 ```bash
-$ recsec -h  # RECordSECtion
+recsec -h  # RECordSECtion
 ```
 
 To plot the waveform data in a record section with default parameters
 
 ```bash
-$ recsec --pysep_path ./SAC
+recsec --pysep_path ./SAC
 ```
 
 To plot a record section with a 7km/s move out, high-pass filtered at 1s
 
 ```bash
-$ recsec --pysep_path ./SAC --move_out 7 --min_period_s 1
+recsec --pysep_path ./SAC --move_out 7 --min_period_s 1
 ```
 
 To sort your record section by azimuth and not distance (default sorting)
 
 ```bash
-$ recsec --pysep_path ./SAC --sort_by azimuth
+recsec --pysep_path ./SAC --sort_by azimuth
 ```
 
 Have a look at the -h/--help message and the docstring at the top of `recsec.py`
 for more options.
 
-#### Plotting SPECFEM synthetics
+### Plotting SPECFEM synthetics
 
 RecSec can plot SPECFEM-generated synthetic seismograms in ASCII format. 
 These can be plotted standalone, or alongside observed seismograms to look at
@@ -173,14 +179,14 @@ SPECFEM3D_Cartesian working directory, plotting synthetics only would have
 the following call structure:
 
 ```bash
-$ recsec --syn_path OUTPUT_FILES/ --cmtsolution DATA/CMTSOLUTION --stations DATA/STATIONS
+recsec --syn_path OUTPUT_FILES/ --cmtsolution DATA/CMTSOLUTION --stations DATA/STATIONS
 ```
 
 To compare observed and synthetic data, you would have name the --pysep_path
 and tell RecSec to preprocess both data streams identically
 
 ```bash
-$ recsec --pysep_path ./SAC --syn_path OUTPUT_FILES/ --cmtsolution DATA/CMTSOLUTION --stations DATA/STATIONS --preprocess both
+recsec --pysep_path ./SAC --syn_path OUTPUT_FILES/ --cmtsolution DATA/CMTSOLUTION --stations DATA/STATIONS --preprocess both
 ```
 
 Preprocessing flags such as filtering and move out will be applied to both
@@ -230,9 +236,9 @@ object as input. Tunable parameters can be fed in as input variables.
 >>> plotw_rs(st=st, sort_by="distance")
 ```
 
-### Miscellaneous Functionality
+## Miscellaneous Functionality
 
-#### Append SAC headers to existing Streams
+### Append SAC headers to existing Streams
 
 To append SAC headers to your own seismic data, you can directly use the
 `PySEP` utility functions `append_sac_headers` and 
@@ -248,7 +254,7 @@ To append SAC headers to your own seismic data, you can directly use the
 >>> st = format_sac_header_w_taup_traveltimes(st=st, model="ak135")
 ```
 
-#### Reading in SPECFEM-generated synthetics
+### Reading in SPECFEM-generated synthetics
 
 PySEP contains a utility function `read_synthetics` to read in 
 SPECFEM-generated synthetics with appropriately crafted SAC headers. 
@@ -263,7 +269,7 @@ might look something like:
 >>> print(st)
 ```
 
-####  Pointing PySEP to custom, local databases 
+###  Pointing PySEP to custom, local databases 
 Data are often stored in custom databases that we cannot predict the 
 structure of. To point PySEP at your local databases, the simplest method would
 be to find a way to read your data and metadata into ObsPy objects, which 
@@ -282,7 +288,7 @@ you can then feed into the PySEP machinery.
 
 --------------------------------------------------------------------------------
 
-### LLNL Note
+## LLNL Note
 
 `PySEP` interfaces with the databases of:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ pip install -e .
 PySEP comes with unit testing which should be run before and after making any
 changes to see if your changes have altered the expected code behavior.
 ```bash
-$ cd pytest/tests
+$ cd pysep/tests
 $ pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,45 @@ you can then feed into the PySEP machinery.
 
 --------------------------------------------------------------------------------
 
+## Running PySEP on UAF Chinook
+
+Chinook is University of Alaska Fairbanks' (UAF) high performance computer. 
+We can run PySEP on Chinook using Docker containers through 
+Singularity/Apptainer. 
+
+By default, PySEP is included in the SCOPED base-container. The following code 
+snippet downloads the correct container and runs the PySEP help message on
+Chinook.
+
+```bash
+module load singularity
+singularity pull docker://ghcr.io/seisscoped/container-base:centos7
+singularity exec -c container-base:centos7.sif pysep -h
+```
+
+To run a data download we will need to mount the local filesystem into the
+container using the ``--bind`` command. Using the Anchorage example event:
+
+```bash
+singularity exec -c --bind $(pwd):/home1 container-base:centos7.sf \
+    bash -c "cd /home1/; pysep -p mtuq_workshop_2022 -e 2009-04-07T201255_ANCHORAGE.yaml"
+```
+
+In the above example, the `-c/--contain` flag preserves the internal container
+filesystem, the `-B/--bind` flag binds the current working directory on Chinook
+(i.e., pwd)to a directory called */home1* within the container, and then the 
+`bash -c` command changes to this */home1* directory and runs PySEP. Files are 
+subsequently saved to the local filesystem in our current working directory.
+
+`RecSec`, the record section plotting tool, can be run from the command line 
+using a similar format. With the Anchorange example files we just generated:
+
+```bash
+cd 2009-04-07T201255_SOUTHERN_ALASKA/
+singularity exec -c --bind $(pwd):/home1 ../container-base_centos7.sif \
+    bash -c "cd /home1; recsec --pysep_path SAC/ --min_period 10 --save record_section_tmin10.png"
+```
+
 ## LLNL Note
 
 `PySEP` interfaces with the databases of:

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ such as the config file and ObsPy objects can be set as in the following:
 
 ```bash
 pysep -c pysep_config.yaml \
-    --event_tag event_abc \
+    --overwrite_event_tag event_abc \
     --config_fid event_abc.yaml \
     --stations_fid event_abc_stations.txt \
     --inv_fid event_abc_inv.xml \

--- a/README.md
+++ b/README.md
@@ -131,6 +131,44 @@ For an example event input file called 'event_input.txt', call structure is:
 ```bash
 pysep -c pysep_config.yaml -E event_input.txt
 ```
+
+--------------------------------------------------------------------------------
+### Legacy Filenaming Schema
+
+The new version of PySEP uses a file naming schema that is incompatible with 
+previous versions, which may lead to problems in established workflows. 
+
+To honor the legacy naming schema of PySEP, simply use the ``--legacy_naming`` 
+argument in the command line. This will change how the event tag is formatted,
+how the output directory is structured, and how the output SAC files are named.
+
+```bash
+$ pysep -c pysep_config.yaml --legacy_naming
+```
+
+--------------------------------------------------------------------------------
+### Output Filename Control
+
+The event tag used to name the output directory and written SAC files can be set
+manually by the user using the ``--event_tag`` argument. If not given, the tag 
+will default to a string consisting of event origin time and Flinn-Engdahl 
+region (or just origin time if ``--legacy_naming`` is used). Other output files 
+such as the config file and ObsPy objects can be set as in the following: 
+
+```bash
+$ pysep -c pysep_config.yaml \
+    --event_tag event_abc \
+    --config_fid event_abc.yaml \
+    --stations_fid event_abc_stations.txt \
+    --inv_fid event_abc_inv.xml \
+    --event_fid event_abc_event.xml \
+    --stream_fid event_abc_st.ms
+```
+
+Please note: the output SAC file names are hardcoded and cannot be changed 
+by the user. If this is a required feature, please open up a GitHub issue, and 
+the developers will address this need.
+
 --------------------------------------------------------------------------------
 
 ## Record Section plotter

--- a/README.md
+++ b/README.md
@@ -254,19 +254,20 @@ To append SAC headers to your own seismic data, you can directly use the
 >>> st = format_sac_header_w_taup_traveltimes(st=st, model="ak135")
 ```
 
-### Reading in SPECFEM-generated synthetics
+### Converting SPECFEM-generated synthetics
 
 PySEP contains a utility function `read_synthetics` to read in 
 SPECFEM-generated synthetics with appropriately crafted SAC headers. 
 Given a standard SPECFEM3D working directory, reading in SPECFEM synthetics 
-might look something like:
+and saving them as SAC files might look something like:
 
 ```python
 >>> from pysep.utils.io import read_synthetics
 >>> st = read_synthetics(fid="OUTPUT_FILES/NZ.BFZ.BXE.semd", 
                          cmtsolution="DATA/CMTSOLUTION", 
                          stations="DATA/STATIONS")
->>> print(st)
+>>> for tr in st:
+>>>     st.write(f"{tr.get_id()}.sac", format="SAC")
 ```
 
 ###  Pointing PySEP to custom, local databases 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ Python Seismogram Extraction and Processing
 ===========================================
 
 `PySEP` is a waveform and metadata download tool. The package also contains
-`RecSec`, a record section plotting tool. 
+`RecSec`, a record section plotting tool. As part of the
+[SCOPED toolkit](https://github.com/SeisSCOPED), `PySEP` is included in the 
+[SCOPED Base container](https://github.com/SeisSCOPED/container-base).
 
 ## Introduction
 

--- a/pysep/configs/alvizuri_tape_2018/2006-10-09T013528_NORTH_KOREA.yaml
+++ b/pysep/configs/alvizuri_tape_2018/2006-10-09T013528_NORTH_KOREA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 20
 remove_clipped: false

--- a/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NODAL.yaml
+++ b/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NODAL.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NONNODAL.yaml
+++ b/pysep/configs/denali_nodal/2019-02-25T182230_CANTWELL_NONNODAL.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/misc_events/1988-02-15T181000_KERNVILLE_EXPLOSION.yaml
+++ b/pysep/configs/misc_events/1988-02-15T181000_KERNVILLE_EXPLOSION.yaml
@@ -35,7 +35,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: 
+pre_filt: default
 scale_factor: 100
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/misc_events/2016-01-24T103037_INISKIN.yaml
+++ b/pysep/configs/misc_events/2016-01-24T103037_INISKIN.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 1
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2009-04-07T201255_ANCHORAGE.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2009-04-07T201255_ANCHORAGE.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2014-08-25T161903_ICELAND.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2014-08-25T161903_ICELAND.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2017-09-03T033001_NORTH_KOREA.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2017-09-03T033001_NORTH_KOREA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 5
 remove_clipped: false

--- a/pysep/configs/mtuq_workshop_2022/2020-04-04T015318_SOUTHERN_CALIFORNIA.yaml
+++ b/pysep/configs/mtuq_workshop_2022/2020-04-04T015318_SOUTHERN_CALIFORNIA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/scec/2002-03-16T213324_SOUTHERN_CALIFORNIA.yaml
+++ b/pysep/configs/scec/2002-03-16T213324_SOUTHERN_CALIFORNIA.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/tape_etal_2018/2012-04-11T092157_TAPE_2018.yaml
+++ b/pysep/configs/tape_etal_2018/2012-04-11T092157_TAPE_2018.yaml
@@ -37,7 +37,7 @@ rotate:
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/configs/template_config.yaml
+++ b/pysep/configs/template_config.yaml
@@ -35,7 +35,7 @@ rotate: null
 remove_response: true
 output_unit: VEL
 water_level: 60
-pre_filt: null
+pre_filt: default
 scale_factor: 100.0
 resample_freq: 50
 remove_clipped: false

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -871,6 +871,15 @@ class Pysep:
             for sta in stations:
                 _st = st_zne.select(station=sta)
                 _inv = self.inv.select(station=sta)
+                # Print out azimuth and dip angles for debugging purposes
+                for _net in _inv:
+                    for _sta in _net:
+                        for _cha in _sta:
+                            logger.debug(
+                                f"rotating -> ZNE "
+                                f"{_net.code}.{_sta.code}.{_cha.code} with "
+                                f"az={_cha.azimuth}, dip={_cha.dip}"
+                            )
                 _st.rotate(method="->ZNE", inventory=self.inv)
             st_out += st_zne
         if "UVW" in self.rotate:
@@ -886,6 +895,7 @@ class Pysep:
             stations = set([tr.stats.station for tr in st_rtz])
             for sta in stations:
                 _st = st_rtz.select(station=sta)
+                logger.debug(f"{sta}: BAz=")
                 _st.rotate(method="NE->RT")  # in place rot.
             st_out += st_rtz
 
@@ -1051,7 +1061,7 @@ class Pysep:
         dict_out = {key: val for key, val in dict_out.items()
                     if not key.startswith("_")}
         # Internal attributes that don't need to go into the written config
-        attr_remove_list = ["st", "event", "inv", "c", "write_files",
+        attr_remove_list = ["st", "st_raw", "event", "inv", "c", "write_files",
                             "plot_files", "output_dir"]
 
         if self.client.upper() != "LLNL":

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -1086,7 +1086,9 @@ class Pysep:
             self.st = st
         self.st = quality_check_waveforms_before_processing(self.st)
         self.st = append_sac_headers(self.st, self.event, self.inv)
-        self.st = format_sac_header_w_taup_traveltimes(self.st, self.taup_model)
+        if self.taup_model is not None:
+            self.st = format_sac_header_w_taup_traveltimes(self.st, 
+                                                           self.taup_model)
 
         # Waveform preprocessing and standardization
         self.st = self.preprocess()

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -17,7 +17,7 @@ import llnl_db_client
 
 from glob import glob
 from pathlib import Path
-from obspy import UTCDateTime
+from obspy import UTCDateTime, Stream
 from obspy.clients.fdsn import Client
 from obspy.clients.fdsn.header import FDSNBadRequestException
 from obspy.core.event import Event, Origin, Magnitude
@@ -829,22 +829,46 @@ class Pysep:
         TODO Original code had a really complicated method for rotating,
             was that necesssary? Why was st.rotate() not acceptable?
 
+        .. warning::
+            This function combines all traces, both rotated and non-rotated
+            components (ZNE, RTZ, UVW, but not raw, e.g., 12Z), into a single
+            stream. This is deemed okay because we don't do any
+            component-specific operations after rotation.
+
         :rtype: obspy.core.stream.Stream
         :return: a stream that has been rotated to desired coordinate system
-            with SAC headers that have been adjusted for the rotation
+            with SAC headers that have been adjusted for the rotation, as well
+            as non-rotated streams which are saved incase user needs access to
+            other components
         """
-        st_out = self.st.copy()
+        st_raw = self.st.copy()
+        st_raw = format_streams_for_rotation(st_raw)
+        # Empty stream so we can take advantage of class __add__ method
+        st_out = Stream()
 
-        st_out = format_streams_for_rotation(st_out)
-        if "ZNE" in self.rotate:
+        # RTZ requires rotating to ZNE first. Make sure this happens even if the
+        # user doesn't specify ZNE rotation.
+        if "ZNE" in self.rotate or "RTZ" in self.rotate:
             logger.info("rotating to components ZNE")
-            st_out.rotate(method="->ZNE", inventory=self.inv)
+            st_zne = st_raw.copy()
+            st_zne.rotate(method="->ZNE", inventory=self.inv)
+            st_out += st_zne
         if "UVW" in self.rotate:
             logger.info("rotating to components UVW")
-            st_out = rotate_to_uvw(st_out)
+            st_uvw = rotate_to_uvw(st_out)
+            st_out += st_uvw
         elif "RTZ" in self.rotate:
             logger.info("rotating to components RTZ")
-            st_out.rotate("NE->RT", inventory=self.inv)
+            # For some reason, when we rotate the ENTIRE stream at once, T and R
+            # components get flipped and shifted (i.e., WRONG). But if we go
+            # station by station, rotation results comes out differently (i.e.,
+            # they match Legacy PySEP results)
+            st_rtz = st_raw.copy()
+            stations = set([tr.stats.station for tr in st_rtz])
+            for sta in stations:
+                _st = st_rtz.select(station=sta)
+                _st.rotate("NE->RT")  # in place rot.
+            st_out += st_rtz
 
         st_out = format_sac_headers_post_rotation(st_out)
 
@@ -897,7 +921,7 @@ class Pysep:
         # but really this set is just required by check(), not by write()
         _acceptable_files = {"weights_az", "weights_dist", "weights_code",
                              "station_list", "inv", "event", "stream",
-                             "config_file", "sac", "all"}
+                             "config_file", "sac", "sac_rotated", "all"}
         if _return_filenames:
             return _acceptable_files
 
@@ -1111,7 +1135,13 @@ class Pysep:
 
         # Waveform preprocessing and standardization
         self.st = self.preprocess()
-        self.st = self.rotate_streams()
+
+        # Rotation to various orientations. The output stream will have ALL
+        # components, both rotated and non-rotated
+        if self.rotate is not None:
+            self.st = self.rotate_streams()
+
+        # Final quality checks on ALL waveforms before we write them out
         self.st = quality_check_waveforms_after_processing(self.st)
 
         # Generate outputs for user consumption

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -900,8 +900,8 @@ class Pysep:
             stations = set([tr.stats.station for tr in st_rtz])
             for sta in stations:
                 _st = st_rtz.select(station=sta)
-                logger.debug(f"{sta}: BAz={_st[0].stats.back_azimuth}")
                 _st.rotate(method="NE->RT")  # in place rot.
+                logger.debug(f"{sta}: BAz={_st[0].stats.back_azimuth}")
             st_out += st_rtz
 
         st_out = format_sac_headers_post_rotation(st_out)

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -653,7 +653,19 @@ class RecordSection:
             for tr, tshift in zip(self.st, self.time_shift_s):
                 start, stop = [int(_/tr.stats.delta) for _ in self.xlim_s]
                 sshift = int(tshift / tr.stats.delta)  # unit: samples
-                xlim.append((start-sshift, stop-sshift))
+                # These indices define the index of the user-chosen timestamp
+                start_index = start - sshift
+                end_index = stop - sshift
+                # Shift by the total amount that the zero pad adjusted starttime
+                if self.zero_pad_s:
+                    zero_pad_index = int(self.zero_pad_s[0]/tr.stats.delta)
+                    start_index += zero_pad_index
+                    end_index += zero_pad_index
+                assert(start_index >= 0), (
+                    f"trying to access negative time but trace has no negative "
+                    f"time values. Please check your choice for `xlim_s`"
+                )
+                xlim.append((start_index, end_index))
 
         xlim = np.array(xlim)
         return xlim

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -298,6 +298,10 @@ class RecordSection:
         if pysep_path is not None and os.path.exists(pysep_path):
             # Expecting to find SAC files labelled as such
             fids = glob(os.path.join(pysep_path, "*.sac"))
+            if not fids:
+                # Or if legacy naming schema, assume that the sac files have a
+                # given file format: event_tag.NN.SSS..LL.CC.c
+                fids = glob(os.path.join(pysep_path, "*.*.*.*.*.?"))
             if fids:
                 logger.info(f"Reading {len(fids)} files from: {pysep_path}")
                 # Overwrite stream, so reading takes precedence

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -141,12 +141,12 @@ class RecordSection:
     3) produces record section waveform figures.
     """
     def __init__(self, pysep_path=None, syn_path=None, stations=None,
-                 cmtsolution=None, st=None, st_syn=None,
-                 sort_by="default", scale_by=None, time_shift_s=None,
+                 cmtsolution=None, st=None, st_syn=None, sort_by="default",
+                 scale_by=None, time_shift_s=None, zero_pad_s=None,
                  move_out=None, min_period_s=None, max_period_s=None,
                  preprocess="st", max_traces_per_rs=None, integrate=0,
                  xlim_s=None, components="ZRTNE12", y_label_loc="default",
-                 y_axis_spacing=1, amplitude_scale_factor=1, 
+                 y_axis_spacing=1, amplitude_scale_factor=1,
                  azimuth_start_deg=0., distance_units="km", 
                  geometric_spreading_factor=0.5, geometric_spreading_k_val=None, 
                  figsize=(9, 11), show=True, save="./record_section.png", 
@@ -207,6 +207,12 @@ class RecordSection:
             2. list (e.g., [5., -2., ... 11.2]), will apply individual time
                 shifts to EACH trace in the stream. The length of this list MUST
                 match the number of traces in your input stream.
+        :type zero_pad_s: list
+        :param zero_pad_s: zero pad data in units of seconsd. applied after
+            tapering and before filtering. Input as a tuple of floats,
+            * (start, end): a list of floats will zero-pad the START and END
+                of the trace. Either can be 0 to ignore zero-padding at either
+                end
         :type amplitude_scale_factor: float OR list of float
         :param amplitude_scale_factor: apply scale factor to all amplitudes.
             Used as a dial to adjust amplitudes manually. Defaults to 1.
@@ -311,8 +317,12 @@ class RecordSection:
 
         # Read in SPECFEM generated synthetics and generate SAC headed streams
         if syn_path is not None and os.path.exists(syn_path):
-            assert(cmtsolution is not None and os.path.exists(cmtsolution))
-            assert(stations is not None and os.path.exists(stations))
+            assert(cmtsolution is not None and os.path.exists(cmtsolution)), (
+                f"If `syn_path` is given, RecSec also requires `cmtsolution`"
+            )
+            assert(stations is not None and os.path.exists(stations)), (
+                f"If `syn_path` is given, RecSec also requires `stations`"
+            )
             fids = glob(os.path.join(syn_path, "??.*.*.sem?*"))
             if fids:
                 logger.info(f"Reading {len(fids)} synthetics from: {syn_path}")
@@ -349,6 +359,7 @@ class RecordSection:
         # Time shift parameters
         self.move_out = move_out
         self.time_shift_s = time_shift_s
+        self.zero_pad_s = zero_pad_s
 
         # Filtering parameters
         self.min_period_s = min_period_s
@@ -459,6 +470,18 @@ class RecordSection:
                     len(self.time_shift_s) != len(self.st):
                 err.time_shift_s = f"must be list of length {len(self.st)}"
 
+        if self.zero_pad_s is not None:
+            assert(isinstance(self.zero_pad_s, list)), (
+                f"`zero_pad_s` must be a list of floats representing the " 
+                f"[`start`, `end`] amount to pad around trace, units seconds"
+            )
+            assert(len(self.zero_pad_s) == 2), (
+                f"`zero_pad_s` must be a list of floats length 2"
+            )
+            _start, _end = self.zero_pad_s
+            assert(_start >= 0. and _end >= 0.), \
+                f"`zero_pad_s` values must be >= 0"
+
         # Defaults to float value of 1
         acceptable_scale_factor = [int, float, list]
         if type(self.amplitude_scale_factor) not in acceptable_scale_factor:
@@ -472,9 +495,14 @@ class RecordSection:
                 err.min_period_s = "must be less than `max_period_s`"
 
         if self.preprocess is not None:
-            acceptable_preprocess = ["both", "st"]
+            acceptable_preprocess = ["both", "st", "st_syn"]
             if self.preprocess not in acceptable_preprocess:
                 err.preprocess = f"must be in {acceptable_preprocess}"
+        if self.preprocess in ["st_syn", "both"]:
+            assert(self.st is not None and self.st_syn is not None), (
+                f"`preprocess` choice requires both `st` & `st_syn` to exist."
+                f"If you only have one or the other, set: `preprocess`=='st'"
+            )
 
         # Overwrite the max traces per record section, enforce type int
         if self.max_traces_per_rs is None:
@@ -503,10 +531,11 @@ class RecordSection:
             err.save = (f"path {self.save} already exists. Use '--overwrite' " 
                         f"flag to save over existing figures.")
 
-        _dirname = os.path.abspath(os.path.dirname(self.save))
-        if not os.path.exists(_dirname):
-            logger.info(f"creating output directory {_dirname}")
-            os.makedirs(_dirname)
+        if self.save:
+            _dirname = os.path.abspath(os.path.dirname(self.save))
+            if not os.path.exists(_dirname):
+                logger.info(f"creating output directory {_dirname}")
+                os.makedirs(_dirname)
 
         if err:
             out = "ERROR - Parameter errors, please make following changes:\n"
@@ -584,7 +613,8 @@ class RecordSection:
         # zoomed in on the P-wave, max amplitude should NOT be the surface wave)
         for tr, xlim in zip(self.st, self.xlim):
             start, stop = xlim
-            self.max_amplitudes.append(max(abs(tr.data[start:stop])))
+            self.max_amplitudes = np.append(self.max_amplitudes,
+                                            max(abs(tr.data[start:stop])))
         self.max_amplitudes = np.array(self.max_amplitudes)
 
         # Figure out which indices we'll be plotting
@@ -1066,6 +1096,16 @@ class RecordSection:
             st.detrend("demean")
             st.taper(max_percentage=0.05, type="cosine")
 
+            # Zero pad start and end of data if requested by user
+            if self.zero_pad_s:
+                _start, _end = self.zero_pad_s
+                logger.info(f"padding zeros to traces with {_start}s before "
+                            f"and {_end}s after")
+                for idx, tr in enumerate(st):
+                    tr.trim(starttime=tr.stats.starttime - _start,
+                            endtime=tr.stats.endtime + _end,
+                            pad=True, fill_value=0)
+
             # Allow multiple filter options based on user input
             # Min period but no max period == low-pass
             if self.max_period_s is not None and self.min_period_s is None:
@@ -1197,8 +1237,11 @@ class RecordSection:
         # Plot actual data on with amplitude scaling, time shift, and y-offset
         tshift = self.time_shift_s[idx]
         
-        # These are still the entire waveform
+        # These are still the entire waveform. Make sure we honor zero padding
+        # and any time shift applied
         x = tr.times() + tshift
+        if self.zero_pad_s is not None:
+            x -= self.zero_pad_s[0]  # index 0 is start, index 1 is end
         y = tr.data / self.amplitude_scaling[idx] + self.y_axis[y_index]
 
         # Truncate waveforms to get figure scaling correct. 
@@ -1329,7 +1372,7 @@ class RecordSection:
             else:
                 loc = self.y_label_loc
             self._set_y_axis_text_labels(start=start, stop=stop, loc=loc)
-        logger.info(f"placing station labels on y-axis at: {loc}")
+            logger.info(f"placing station labels on y-axis at: {loc}")
 
         # User requests that we turn off y-axis
         if self.y_label_loc is None:
@@ -1669,6 +1712,12 @@ def parse_args():
     parser.add_argument("--xlim_s", default=None, type=int, nargs="+",
                         help="Min and max x limits in units seconds. Input as "
                              "a list, e.g., --xlim_s 10 200 ...")
+    parser.add_argument("--zero_pad_s", default=None, type=float, nargs="+",
+                        help="Zero pad the start and end of each trace. Input "
+                             "as two values in units of seconds."
+                             "i.e., --zero_pad_s `START` `END` or"
+                             "e.g., --zero_pad_s 30 0 to pad 30s before start "
+                             "0s at end of trace")
     parser.add_argument("--components", default="ZRTNE12", type=str, nargs="?",
                         help="Ordered component list specifying 1) which "
                              "components will be shown, and in what order. "

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1554,6 +1554,11 @@ class RecordSection:
         y_fmt = f"Y_FMT: NET.STA.LOC.CHA|{az_str}|DIST"
         if self.time_shift_s.sum() != 0:
             y_fmt += "|TSHIFT"
+        # Zero pad is either a list of length or None
+        if self.zero_pad_s:
+            _start, _end = self.zero_pad_s
+        else:
+            _start, _end = 0, 0
 
         title = "\n".join([
             title_top,
@@ -1566,6 +1571,7 @@ class RecordSection:
             f"SCALE_BY: {self.scale_by} * {self.amplitude_scale_factor}",
             f"FILT: [{self.min_period_s}, {self.max_period_s}]s; "
             f"MOVE_OUT: {self.move_out or 0}{self.distance_units}/s",
+            f"ZERO_PAD: {_start}s, {_end}s",
         ])
         self.ax.set_title(title)
 

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -1559,11 +1559,14 @@ class RecordSection:
             _start, _end = self.zero_pad_s
         else:
             _start, _end = 0, 0
+        # Origintime needs to be shifted by the zero pad offset value which has
+        # changed the 'starttime'
+        origintime = min([tr.stats.starttime + _start for tr in self.st])
 
         title = "\n".join([
             title_top,
             f"{'/' * len(title_top*2)}",
-            f"ORIGINTIME: {min([tr.stats.starttime for tr in self.st])}",
+            f"ORIGINTIME: {origintime}",
             f"{y_fmt}",
             f"NWAV: {nwav}; NEVT: {self.stats.nevents}; "
             f"NSTA: {self.stats.nstation}; COMP: {cmp}",

--- a/pysep/tests/test_pysep.py
+++ b/pysep/tests/test_pysep.py
@@ -74,3 +74,4 @@ def test_curtail_stations(test_pysep):
     nsta_post_curtail = len(inv.get_contents()["channels"])
 
     assert(nsta_pre_curtail - nsta_post_curtail == 6)
+

--- a/pysep/tests/test_recsec.py
+++ b/pysep/tests/test_recsec.py
@@ -1,0 +1,123 @@
+"""
+Test the general functionality of the RECord SECtion plotter.
+
+.. note::
+    This test suite simply creates some plots to make sure the general
+    machinery is working as expected, but otherwise has no real solid checks on
+    the outputs. If this code grows more cumbersome, we will want to do figure
+    matching checks or something more sophisticated.
+"""
+import os
+import pytest
+from copy import copy
+from pysep import RecordSection
+
+
+@pytest.fixture
+def recsec(tmpdir):
+    """Initiate a RecordSection instance"""
+    return RecordSection(pysep_path="./test_data/test_SAC", show=False,
+                         save=os.path.join(tmpdir, "recsec.png"))
+
+
+@pytest.fixture
+def recsec_w_synthetics(tmpdir):
+    """Initiate a RecordSection instance"""
+    return RecordSection(pysep_path="./test_data/test_SAC",
+                         syn_path="./test_data/test_synthetics",
+                         cmtsolution="./test_data/test_CMTSOLUTION_2014p715167",
+                         stations="./test_data/test_STATIONS",
+                         show=False, save=os.path.join(tmpdir, "recsec.png"))
+
+
+def test_plot_recsec(recsec):
+    """Simply test out the functinoality of plotw_rs"""
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()
+
+
+def test_plot_recsec_w_synthetics(recsec_w_synthetics):
+    """Simply test out the functinoality of plotw_rs"""
+    recsec_w_synthetics.process_st()
+    recsec_w_synthetics.get_parameters()
+    recsec_w_synthetics.plot()
+
+
+def test_plot_recsec_sort_by(recsec):
+    """Simply test out the functinoality of plotw_rs"""
+    acceptable_sort_by = ["default", "azimuth", "backazimuth",
+                          "distance", "alphabetical", "abs_azimuth",
+                          "abs_distance"]
+    for sort_by in acceptable_sort_by:
+        recsec_test = copy(recsec)
+        recsec_test.sort_by = sort_by
+        recsec_test.process_st()
+        recsec_test.get_parameters()
+        recsec_test.save = f"{recsec.save}_{sort_by}.png"
+        recsec_test.plot()
+
+
+def test_plot_recsec_scale_by(recsec):
+    """scale by option testing"""
+    acceptable_scale_by = ["normalize", "global_norm"]
+                           # "geometric_spreading"]
+    for scale_by in acceptable_scale_by:
+        recsec_test = copy(recsec)
+        recsec_test.scale_by = scale_by
+        recsec_test.process_st()
+        recsec_test.get_parameters()
+        recsec_test.save = f"{recsec.save}_{scale_by}.png"
+        recsec_test.plot()
+
+
+def test_plot_recsec_time_shift(recsec):
+    """apply a whole bunch of time shift elements"""
+    recsec.time_shift_s = 100
+    recsec.zero_pad_s = [200, 500]
+    recsec.move_out = 4
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()
+
+
+def test_plot_recsec_preprocess(recsec):
+    """preprocess and filter the record section"""
+    recsec.min_period_s = 10
+    recsec.max_period_s = 30
+    recsec.integrate = 2
+    recsec.components = "ZN"
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()
+
+
+def test_plot_recsec_y_label_loc(recsec):
+    """test all available y_label locations options"""
+    acceptable_y_label_loc = ["default", "y_axis", "y_axis_right", "x_min",
+                              "x_max", None]
+    recsec.process_st()
+    recsec.get_parameters()
+    for y_label_loc in acceptable_y_label_loc:
+        recsec.y_label_loc = y_label_loc
+        recsec.plot()
+
+
+def test_plot_recsec_distance_units(recsec):
+    """test all available distance units"""
+    acceptable_distance_units = ["km", "km_utm", "deg"]
+    for distance_units in acceptable_distance_units:
+        recsec.distance_units = distance_units
+        recsec.process_st()
+        recsec.get_parameters()
+        recsec.plot()
+
+
+def test_plot_recsec_plot_options(recsec):
+    """test plotting options"""
+    recsec.y_axis_spacing = 3.5
+    recsec.amplitude_scale_factor = 8.2
+    recsec.azimuth_start_deg = 102.1
+    recsec.process_st()
+    recsec.get_parameters()
+    recsec.plot()

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -15,6 +15,7 @@ from pysep.utils.curtail import (remove_for_clipped_amplitudes, rename_channels,
                                  remove_stations_for_missing_channels,
                                  remove_stations_for_insufficient_length)
 from pysep.utils.fmt import format_event_tag, format_event_tag_legacy
+from pysep.utils.process import estimate_prefilter_corners
 from pysep.utils.plot import plot_source_receiver_map
 from pysep.utils.io import read_synthetics
 
@@ -149,6 +150,18 @@ def test_read_synthetics():
                               stations=test_stations)
 
     assert(st[0].stats.sac.evla == -40.5405)
+
+
+def test_estimate_prefilter_corners(test_st):
+    """
+    Test prefilter corner estimation based on trace starts time and samp rate
+    """
+    for tr in test_st:
+        f0, f1, f2, f3 = estimate_prefilter_corners(tr)
+        assert(f0 == pytest.approx(.0214, 3))
+        assert(f1 == pytest.approx(.0427, 3))
+        assert(f2 == pytest.approx(12.5, 3))
+        assert(f3 == pytest.approx(25.0, 3))
 
 
 @pytest.mark.skip(reason="need to find correct clipped example data")

--- a/pysep/tests/test_utils.py
+++ b/pysep/tests/test_utils.py
@@ -8,13 +8,13 @@ import os
 import pytest
 from glob import glob
 from obspy import read, read_events, read_inventory, Stream
-
+from obspy.io.sac.sactrace import SACTrace
 from pysep.utils.cap_sac import (append_sac_headers,
                                  format_sac_header_w_taup_traveltimes)
 from pysep.utils.curtail import (remove_for_clipped_amplitudes, rename_channels,
                                  remove_stations_for_missing_channels,
                                  remove_stations_for_insufficient_length)
-from pysep.utils.fmt import format_event_tag
+from pysep.utils.fmt import format_event_tag, format_event_tag_legacy
 from pysep.utils.plot import plot_source_receiver_map
 from pysep.utils.io import read_synthetics
 
@@ -52,9 +52,17 @@ def test_append_sac_headers(test_st, test_inv, test_event):
     assert(hasattr(st[0].stats, "sac"))
     assert(st[0].stats.sac["evla"] == test_event.preferred_origin().latitude)
 
+
+def test_event_tag_and_event_tag_legacy(test_event):
+    """
+    Check that event tagging works as expected
+    """
     # while were here, make sure event tagging works
     tag = format_event_tag(test_event)
     assert(tag == "2009-04-07T201255_SOUTHERN_ALASKA")
+
+    tag = format_event_tag_legacy(test_event)
+    assert(tag == "20090407201255351")
 
 
 def test_format_sac_headers_w_taup_traveltimes(test_st, test_inv, test_event):
@@ -64,6 +72,17 @@ def test_format_sac_headers_w_taup_traveltimes(test_st, test_inv, test_event):
     st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
     st = format_sac_header_w_taup_traveltimes(st=st, model="ak135")
     assert(pytest.approx(st[0].stats.sac["user4"], .01) == 57.66)
+
+
+def test_sac_header_correct_origin_time(tmpdir, test_st, test_inv, test_event):
+    """
+    Make sure SAC headers are being written with 0 as the event origin time and
+    not the trace start time
+    """
+    st = append_sac_headers(st=test_st, inv=test_inv, event=test_event)
+    st[0].write(os.path.join(tmpdir, "test.sac"), format="SAC")  # only write 1
+    sac = SACTrace.read(os.path.join(tmpdir, "test.sac"))
+    assert(sac.reftime == test_event.preferred_origin().time)
 
 
 def test_rename_channels(test_st):

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -142,7 +142,8 @@ def append_sac_headers(st, event, inv):
 
 def _append_sac_headers_trace(tr, event, inv):
     """
-    Append SAC headers to ObsPy streams given event and station metadata
+    Append SAC headers to ObsPy streams given event and station metadata.
+    Also add 'back_azimuth' to Stream stats which can be used for rotation.
 
     Rewritten from: `util_write_cap.add_sac_metadata()`
 
@@ -205,6 +206,7 @@ def _append_sac_headers_trace(tr, event, inv):
     except IndexError:
         pass
 
+    # Append SAC header and include back azimuth for rotation
     tr.stats.sac = sac_header
     tr.stats.back_azimuth = baz
 

--- a/pysep/utils/cap_sac.py
+++ b/pysep/utils/cap_sac.py
@@ -10,7 +10,7 @@ from obspy.core.stream import Stream
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from pysep import logger
-from pysep.utils.fmt import format_event_tag
+from pysep.utils.fmt import format_event_tag_legacy
 from pysep.utils.fetch import get_taup_arrivals_with_sac_headers
 
 # SAC HEADER CONSTANTS DEFINING NON-INTUITIVE QUANTITIES
@@ -149,6 +149,11 @@ def _append_sac_headers_trace(tr, event, inv):
     TODO Add back in information removed from original function
         * Add sensor type somewhere, previously stored in KT? (used for picks)
 
+    .. note::
+        We explicitely set 'iztype, 'b' and 'e' in the SAC header to tell ObsPy
+        that the trace start is NOT the origin time. Otherwise all the relative
+        timing (e.g., picks) will be wrong.
+
     :type tr: obspy.core.trace.Trace
     :param tr: Trace to append SAC header to
     :type event: obspy.core.event.Event
@@ -174,6 +179,9 @@ def _append_sac_headers_trace(tr, event, inv):
     dist_deg = kilometer2degrees(dist_km)  # spherical earth approximation
 
     sac_header = {
+        "iztype": 9,  # Ref time equivalence, IB (9): Begin time
+        "b": tr.stats.starttime - event.preferred_origin().time,  # begin time
+        "e": tr.stats.npts * tr.stats.delta,  # end time
         "evla": event.preferred_origin().latitude,
         "evlo": event.preferred_origin().longitude,
         "evdp": event.preferred_origin().depth / 1E3,  # depth in km
@@ -181,7 +189,7 @@ def _append_sac_headers_trace(tr, event, inv):
         "stla": sta.latitude,
         "stlo": sta.longitude,
         "stel": sta.elevation / 1E3,  # elevation in km
-        "kevnm": format_event_tag(event),
+        "kevnm": format_event_tag_legacy(event),  # only take date code
         "dist": dist_km,
         "az": az,  # degrees
         "baz": baz,  # degrees

--- a/pysep/utils/fmt.py
+++ b/pysep/utils/fmt.py
@@ -78,3 +78,17 @@ def format_event_tag(event):
     event_time = event.preferred_origin().time.strftime("%Y-%m-%dT%H%M%S")
 
     return f"{event_time}_{region}"
+
+
+def format_event_tag_legacy(event):
+    """
+    Generate a unique event tag based on the event time. This was how the
+    previous version of PySEP named directories and files. Replaces the old
+    `otime2eid` from `util_helpers`
+
+    :type event: obspy.core.event.Event
+    :param event: event to generate tag from
+    :rtype: str
+    :return: event_name specified by event time
+    """
+    return event.preferred_origin().time.strftime("%Y%m%d%H%M%S%f")[:-3]

--- a/pysep/utils/fmt.py
+++ b/pysep/utils/fmt.py
@@ -72,9 +72,10 @@ def format_event_tag(event):
 
     client = Client()
     region = client.flinnengdahl(lat=event_lat, lon=event_lon, rtype="region")
+    # e.g. NORTH ISLAND, NEW ZEALAND > NORTH_ISLAND_NEW_ZEALAND
     region = region.replace(" ", "_").replace(",", "").upper()
 
-    # Presumed to be event name specified by origintime
+    # Presumed to be event name specified by origintime, e..g, 20090407T201255
     event_time = event.preferred_origin().time.strftime("%Y-%m-%dT%H%M%S")
 
     return f"{event_time}_{region}"

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -316,3 +316,31 @@ def zerophase_chebychev_lowpass_filter(tr, freqmax):
                          output="ba")                                   # NOQA
     # Apply twice to get rid of the phase distortion.
     tr.data = signal.filtfilt(b, a, tr.data)
+
+
+def estimate_prefilter_corners(tr):
+    """
+    Estimates corners for pre-deconvolution (instrument response removal)
+    Essentially band limits the data based on the minimum and maximum allowable
+    periods based on the sampling rate and overall waveform length.
+
+    See also: https://ds.iris.edu/files/sac-manual/commands/transfer.html
+
+    Replaces the old `get_pre_filt` function
+
+    :type tr: obspy.core.trace.Trace
+    :param tr: trace from which stats are taken
+    :rtype: tuple of float
+    :return: frequency corners (f0, f1, f2, f3)
+    """
+    # filtering constants
+    fcut1_par = 4.0
+    fcut2_par = 0.5
+
+    f1 = fcut1_par / (tr.stats.endtime - tr.stats.starttime)
+    nyquist_freq = tr.stats.sampling_rate / 2
+    f2 = nyquist_freq * fcut2_par
+    f0 = 0.5 * f1
+    f3 = 2.0 * f2
+
+    return f0, f1, f2, f3

--- a/pysep/utils/process.py
+++ b/pysep/utils/process.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy import signal
 
 from obspy import Stream
+from obspy.geodetics import gps2dist_azimuth
 from pysep import logger
 from pysep.utils.fmt import get_codes
 
@@ -56,6 +57,41 @@ def format_streams_for_rotation(st):
 
     logger.info(f"stream formatting returned {len(st_out)} traces")
 
+    return st_out
+
+
+def append_back_azimuth_to_stats(st, inv, event):
+    """
+    ObsPy rotation requires back azimuth information which is accessed through
+    trace.stats.back_azimuth. This function appends back azimuth values to the
+    stream by cacluating using metadata from the inventory and event objects.
+
+    .. note::
+        This was written and then I realized that `_append_sac_headers_trace`
+        already does this, so it is unused, but left incase it's useful later.
+
+    :type st: obspy.core.stream.Stream
+    :param st: Stream with missing components
+    :type inv: obspy.core.inventory.Inventory
+    :param inv: optional user-provided inventory object which will force a
+        skip over StationXML/inventory searching
+    :type event: obspy.core.event.Event
+    :param event: optional user-provided event object which will force a
+        skip over QuakeML/event searching
+    :rtype: obspy.core.stream.Stream
+    :return: stream with back azimuth values appended
+    """
+    st_out = st.copy()
+    ev_lat = event.preferred_origin().latitude
+    ev_lon = event.preferred_origin().longitude
+    for net in inv:
+        for sta in net:
+            _, _, baz = gps2dist_azimuth(lat1=ev_lat, lon1=ev_lon,
+                                         lat2=sta.latitude, lon2=sta.longitude
+                                         )
+            # Apply back azimuth changes to stream in place
+            for tr in st_out.select(network=net.code, station=sta.code):
+                tr.stats.back_azimuth = baz
     return st_out
 
 


### PR DESCRIPTION
This PR introduces features and bug fixes from the devel branch into master:

Features:
- User can choose to use 'legacy_naming' to match file name schema of old Pysep
- Allow User to ignore using TauP model to phase pick
- RecSec now recognizes legacy SAC filenames
- Re-introduces pre-filtering that occurs before filtering to band-limit data based on sampling rate / waveform length
- RecSec now has a zero-pad feature for padding front and back of traces 

Bug Fixes:
- SAC header KEVNM is now limited to 16 characters in house 
- SAC header set iztype, e and b to get correct origin time and reference time
- Rotation to ZNE was ignored if components already in NE. Now rotation is forced by sensor angles regardless of original components
- Rotation to RTZ for entire stream caused all stations to be rotated by 1 backazimuth 