### PR TITLE
Feature sem2d recsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,12 @@ for more options.
 
 ### Plotting SPECFEM synthetics
 
-RecSec can plot SPECFEM-generated synthetic seismograms in ASCII format. 
-These can be plotted standalone, or alongside observed seismograms to look at
-data-synthetic misfit. 
+RecSec can plot SPECFEM-generated synthetic seismograms in ASCII format. Here 
+the domain should be defined by geographic coordinates (latitude/longitude). If 
+your domain is defined in Cartesian, see below.
+
+Record sections  can be plotted standalone, or alongside observed seismograms 
+to look at data-synthetic misfit. 
 
 To access metadata, RecSec requires the CMTSOLUTION and STATIONS file that were 
 used by SPECFEM to generate the synthetics. Based on a standard 
@@ -234,6 +237,31 @@ recsec --pysep_path ./SAC --syn_path OUTPUT_FILES/ --cmtsolution DATA/CMTSOLUTIO
 
 Preprocessing flags such as filtering and move out will be applied to both
 observed and synthetic data.
+
+### Plotting SPECFEM synthetics in Cartesian
+
+Under the hood, RecSec uses some of ObsPy's geodetic
+functions to calculate distances and azimuths. Because of this, RecSec will 
+fail if coordinates are defined in a Cartesian coordinate system (XYZ), which 
+may often be the case when working in SPECFEM2D or in a local domain of 
+SPECFEM3D_Cartesian.
+
+To circumvent this, RecSec has a flag `--cartesian`, which will swap out the 
+read functions to work with a Cartesian coordinate system. The call is very 
+similar to the above:
+
+For SPECFEM3D_Cartesian this would look like
+
+```bash
+recsec --syn_path OUTPUT_FILES --cmtsolution DATA/CMTSOLUTION --stations DATA/STATIONS --cartesian
+```
+
+For SPECFEM2D, the source file may not be a CMTSOLUTION. Additionally, the 
+default seismogram components may not be defined in ZNE
+
+```bash
+recsec --syn_path OUTPUT_FILES --cmtsolution DATA/SOURCE --stations DATA/STATIONS --components Y --cartesian
+```
 
 --------------------------------------------------------------------------------
 

--- a/pysep/pysep.py
+++ b/pysep/pysep.py
@@ -13,7 +13,7 @@ import os
 import sys
 import yaml
 import warnings
-import llnl_db_client
+import llnl_db_client  # NOQA
 
 from glob import glob
 from pathlib import Path

--- a/pysep/recsec.py
+++ b/pysep/recsec.py
@@ -96,7 +96,7 @@ from obspy import read, Stream
 from obspy.geodetics import (kilometers2degrees, gps2dist_azimuth)
 
 from pysep import logger
-from pysep.utils.io import read_synthetics
+from pysep.utils.io import read_synthetics, read_synthetics_cartesian
 
 # Unicode degree symbol for plot text
 DEG = u"\N{DEGREE SIGN}"
@@ -328,7 +328,8 @@ class RecordSection:
                 logger.info(f"Reading {len(fids)} synthetics from: {syn_path}")
                 st_syn = Stream()
                 for fid in fids:
-                    st_syn += read_synthetics(fid=fid, cmtsolution=cmtsolution,
+                    logger.debug(fid)
+                    st_syn += read_synthetics_cartesian(fid=fid, source=cmtsolution,
                                               stations=stations)
         # Allow plotting ONLY synthetics and no data
         if st is None:
@@ -848,7 +849,7 @@ class RecordSection:
             # Overwrite `dist`, could probably skip that calc above but
             # leaving for now as I don't think this option will be used heavily.
             dist_deg = np.sqrt(
-                ((tr.stats.sac.stlo - tr.stats.sac.evlo) ** 2) /
+                ((tr.stats.sac.stlo - tr.stats.sac.evlo) ** 2) +
                 ((tr.stats.sac.stla - tr.stats.sac.evla) ** 2)
             )
             dist = kilometers2degrees(dist_deg)  # units: km


### PR DESCRIPTION
This PR introduces the feature to plot record sections from SPECFEM2D synthetics.

This was not possible before as RecSec did not have the ability to read SPECFEM2D SOURCE files.
Nor did it have the capability to handle Cartesian domains (only geographic). Which was also a boon for SPECFEM3D_Cartesian domains.

RecSec can how handle both of these features and creates a barebones SAC header that is only used to complete the record section. Tested with some 2D synthetics generated using the SeisFlows Example 2 workflow.